### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/Subproject/tkitText/setup.py
+++ b/Subproject/tkitText/setup.py
@@ -35,7 +35,7 @@ setup(
         # 'bs4==0.0.1',
         # 'MagicBaidu==0.0.9',
         # 'requests==2.21.0',
-        'fuzzywuzzy==0.17.0',
+        'rapidfuzz==0.7.3',
         'textrank4zh==0.3',
         'readability-lxml==0.7.1',
         'html2text==2019.9.26',

--- a/Subproject/tkitText/tkitText/text.py
+++ b/Subproject/tkitText/tkitText/text.py
@@ -11,8 +11,8 @@ from harvesttext import HarvestText
 from tqdm import tqdm
 import  hashlib
 
-from fuzzywuzzy import fuzz
-# from fuzzywuzzy import process
+from rapidfuzz import fuzz
+# from rapidfuzz import process
 
 
 import jieba.analyse


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy